### PR TITLE
[Bugfix] Avoid Py2 division downcasting

### DIFF
--- a/PyBASC/basc.py
+++ b/PyBASC/basc.py
@@ -318,17 +318,12 @@ def join_group_stability(
     import PyBASC.utils as utils
     import scipy.sparse
 
-
-
     group_stability_set = np.asarray([
         scipy.sparse.load_npz(G_file).toarray() for G_file in group_stability_list
     ])
 
     gsm = group_stability_set.sum(axis=0)
-    G = gsm / n_bootstraps
-    
-
-    G = G * 100
+    G = gsm / float(n_bootstraps) * 100
     G = G.astype("uint8")
 
     if group_dim_reduce:
@@ -340,8 +335,6 @@ def join_group_stability(
         G = G.toarray()
 
     roi_mask_data = nb.load(roi_mask_file).get_data().astype('bool')
-    
-    
     
     clusters_G = utils.cluster_timeseries(
         G, roi_mask_data, n_clusters,

--- a/PyBASC/basc.py
+++ b/PyBASC/basc.py
@@ -322,8 +322,9 @@ def join_group_stability(
         scipy.sparse.load_npz(G_file).toarray() for G_file in group_stability_list
     ])
 
-    gsm = group_stability_set.sum(axis=0)
-    G = gsm / float(n_bootstraps) * 100
+    G = group_stability_set.sum(axis=0)
+    G *= 100
+    G //= n_bootstraps
     G = G.astype("uint8")
 
     if group_dim_reduce:

--- a/PyBASC/pipeline.py
+++ b/PyBASC/pipeline.py
@@ -94,6 +94,9 @@ def create_basc(proc_mem, name='basc'):
     >>> from CPAC import basc
 
     """
+
+    mem_per_proc = float(proc_mem[1]) / float(proc_mem[0])
+
     basc = pe.Workflow(name=name)
 
     inputspec = pe.Node(util.IdentityInterface(fields=[
@@ -148,9 +151,9 @@ def create_basc(proc_mem, name='basc'):
             function=group_dim_reduce
         ),
         name='group_dim_reduce', 
-	mem_gb=proc_mem[1]/proc_mem[0]
+        mem_gb=mem_per_proc
     )
-    #gdr.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #gdr.interface.estimated_memory_gb=mem_per_proc
 
     nis = pe.MapNode(
         util.Function(
@@ -172,11 +175,11 @@ def create_basc(proc_mem, name='basc'):
             function=nifti_individual_stability
         ),
         name='individual_stability_matrices',
-	mem_gb=proc_mem[1]/proc_mem[0],
+        mem_gb=mem_per_proc,
         iterfield=['subject_file',
                    'affinity_threshold']
     )
-    #nis.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #nis.interface.estimated_memory_gb=mem_per_proc
     nis.inputs.cbb_block_size = None
 
     mgsm = pe.MapNode(
@@ -191,10 +194,10 @@ def create_basc(proc_mem, name='basc'):
             function=map_group_stability
         ),
         name='map_group_stability',
-	mem_gb=proc_mem[1]/proc_mem[0],
+        mem_gb=mem_per_proc,
         iterfield='bootstrap_list'
     )
-    #mgsm.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #mgsm.interface.estimated_memory_gb=mem_per_proc
 
     jgsm = pe.Node(
         util.Function(
@@ -215,9 +218,9 @@ def create_basc(proc_mem, name='basc'):
             function=join_group_stability
         ),
         name='join_group_stability',
-	mem_gb=proc_mem[1]/proc_mem[0]
+        mem_gb=mem_per_proc
     )
-    #jgsm.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #jgsm.interface.estimated_memory_gb=mem_per_proc
     
 
     
@@ -234,11 +237,11 @@ def create_basc(proc_mem, name='basc'):
             function=individual_group_clustered_maps
         ),
         name='individual_group_clustered_maps',
-	mem_gb=proc_mem[1]/proc_mem[0],
+        mem_gb=mem_per_proc,
         iterfield=['subject_stability_list', 'compression_labels_file']
     )
         
-    #igcm.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #igcm.interface.estimated_memory_gb=mem_per_proc
 
     post = pe.Node(
         util.Function(
@@ -247,9 +250,9 @@ def create_basc(proc_mem, name='basc'):
             function=post_analysis
         ),
         name='post_analysis',
-	mem_gb=proc_mem[1]/proc_mem[0]
+        mem_gb=mem_per_proc
     )
-    #post.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #post.interface.estimated_memory_gb=mem_per_proc
 
     gs_cluster_vol = pe.Node(
         util.Function(
@@ -261,9 +264,9 @@ def create_basc(proc_mem, name='basc'):
             function=ndarray_to_vol
         ),
         name='group_stability_cluster_vol',
-	mem_gb=proc_mem[1]/proc_mem[0]
+        mem_gb=mem_per_proc
     )
-    #gs_cluster_vol.interface.estimated_memory_gb=proc_mem[1]/proc_mem[0]
+    #gs_cluster_vol.interface.estimated_memory_gb=mem_per_proc
 
     gs_cluster_vol.inputs.filename = 'group_stability_clusters.nii.gz'
 

--- a/PyBASC/utils.py
+++ b/PyBASC/utils.py
@@ -553,8 +553,8 @@ def individual_stability_matrix(
                 )
             )
         
-        S /= float(n_bootstraps)
         S *= 100
+        S //= n_bootstraps
         S = S.astype("uint8")
 
     else:
@@ -578,8 +578,8 @@ def individual_stability_matrix(
                 )[:, np.newaxis]
             )
 
-        S /= float(n_bootstraps)
         S *= 100
+        S //= n_bootstraps
         S = S.astype("uint8")
 
     return S

--- a/PyBASC/utils.py
+++ b/PyBASC/utils.py
@@ -553,10 +553,9 @@ def individual_stability_matrix(
                 )
             )
         
-        S /= n_bootstraps
+        S /= float(n_bootstraps)
         S *= 100
         S = S.astype("uint8")
-
 
     else:
         for _ in range(n_bootstraps):
@@ -579,7 +578,7 @@ def individual_stability_matrix(
                 )[:, np.newaxis]
             )
 
-        S /= n_bootstraps
+        S /= float(n_bootstraps)
         S *= 100
         S = S.astype("uint8")
 


### PR DESCRIPTION
On Python2, `int / int` results in a `int` value, but `float / int` or `int / float` result in a `float`. The latter is required on PyBASC group stability computation.

Since the values are downcasted to integers afterwards, the solution of first multiplying by 100 and after dividing by n_bootstraps achieves the same result without needing to upcast the matrix to float.

e.g.:
`(15 * 100) // 7 == int(15.0 / 7 * 100)`